### PR TITLE
refactor: 마이그레이션 CLI 플로우 및 인터페이스 개선

### DIFF
--- a/app/cli.cjs
+++ b/app/cli.cjs
@@ -93,11 +93,17 @@ const inquirer = require('inquirer');
 //   logError   : 빨강 ✖  (치명적 에러, process.exit 전)
 //   logStep    : 회색 ·  (하위 진행 항목·부가 정보)
 // =========================================================
-const SEP = chalk.gray('─'.repeat(50));
-function logSection(title) { console.log('\n' + chalk.blue.bold(title)); console.log(SEP); }
+const SEP = chalk.gray('──────────────────────────────────────────────────────────────────────────────────────────────────────');
+function logSection(title) {
+  console.log('\n' + chalk.blue.bold(title));
+  if (!/^Part \d+ \(/.test(title)) {
+    console.log(SEP);
+  }
+}
 function logSuccess(msg)   { console.log(chalk.green('✔ ' + msg)); }
 function logWarn(msg)      { console.log(chalk.yellow('⚠ ' + msg)); }
 function logError(msg)     { console.error(chalk.red('✖ ' + msg)); }
+function logInfo(msg)      { console.log(chalk.white('  · ' + msg)); }
 function logStep(msg)      { console.log(chalk.gray('  · ' + msg)); }
 
 // 모듈 경로 변경 (step 폴더의 index.cjs )
@@ -107,8 +113,8 @@ const { runStep3 } = require('./src/step3/index.cjs');
 const { runStep4 } = require('./src/step4/index.cjs');
 const { runStep5 } = require('./src/step5/index.cjs');
 const { runStep6 } = require('./src/step6/index.cjs');
-const { runStep7 } = require('./src/step7/index.cjs');
 const { runValidation } = require('./src/validation/index.cjs');
+const { runEnvAndDependencyGuide, guideDependencyReset } = require('./src/step6/env-guide.cjs');
 
 const {
   detectPackageManager,
@@ -134,9 +140,11 @@ const {
 const { generateText, createMigrationPrompt, generateTextStream } = require('./src/utils/gemini-client.cjs');
 const { runAskApply } = require('./src/utils/ai-file-apply.cjs');
 const { runAiReviewSessionStream } = require('./src/utils/ai-review-session.cjs');
-const { ensureGeminiCliReady } = require('./src/utils/gemini-cli-setup.cjs');
 const { printRelPathsBlock } = require('./src/utils/path-list-print.cjs');
-const { generatePerformanceReport, createPreStep7Snapshot } = require('./src/step7/performance-report.cjs');
+const {
+  createBaseMigrationSnapshot,
+  ensureNextifyMeta,
+} = require('./src/step7/performance-report.cjs');
 const fs = require('fs-extra');
 const pkg = require('./package.json');
 
@@ -148,16 +156,15 @@ program.addHelpText(
   'after',
   `\n예시:\n` +
     `  migrate-next\n` +
-    `    - step1~step6 실행 후, 다음 항목을 각각 yes/no 로 선택합니다:\n` +
-    `        1) Next.js 심화 변환(step7: next/image, next/font, Dynamic Import 등)\n` +
-    `        2) 성능 비교 레포트 생성 (Lighthouse 측정)\n` +
-    `        3) Gemini CLI 코드 리뷰 (view-only)\n` +
-    `    - Gemini CLI 미설치 시 자동 설치를 시도합니다(리뷰를 선택한 경우). 진행 중 Ctrl+C는 Gemini CLI 리뷰만 중단합니다.\n` +
+    `    - step1~step5 기본 마이그레이션과 TypeScript 검증을 실행합니다.\n` +
+    `    - Next.js 심화 변환, 성능 레포트, AI 리뷰는 별도 명령으로 실행합니다.\n` +
+    `  migrate-next advanced\n` +
+    `    - Next.js 심화 변환(step6: next/image, next/font, Dynamic Import 등)을 실행합니다.\n` +
     `  migrate-next steps\n` +
-    `    - 같은 폴더에서 step1~step7만 순차 실행합니다. (\`.ai-migration\`/성능 레포트/Gemini 리뷰는 만들지 않습니다.)\n` +
+    `    - 같은 폴더에서 step1~step6까지 순차 실행합니다. (\`.ai-migration\`/성능 레포트/Gemini 리뷰는 만들지 않습니다.)\n` +
     `    - 이후 \`migrate-next report\`(레포트) 또는 \`migrate-next review\`(리뷰)로 부분 기능만 별도 실행할 수 있습니다.\n` +
     `  migrate-next review\n` +
-    `    - 기존 .ai-migration/stepN/session.json 으로 Gemini CLI 리뷰만 단독 실행 (\`--session <path>\` 지정 가능).\n` +
+    `    - 기존 .ai-migration/stepN/session.json 으로 diff 확인과 Gemini CLI 리뷰를 실행합니다.\n` +
     `  migrate-next report\n` +
     `    - 성능 비교 레포트만 별도 재생성.\n` +
     `\n레거시(기존 step1 preview clone 방식):\n` +
@@ -279,7 +286,11 @@ program
       }
 
       if (mode === 'copy') {
-        await cloneProject(cwd, targetPath);
+        await cloneProject(cwd, targetPath, {
+          startMessage: '작업용 프로젝트를 복사하는 중...',
+          successMessage: `작업용 프로젝트 복사 완료: ${targetPath}`,
+          failMessage: '작업용 프로젝트 복사 실패',
+        });
         process.chdir(targetPath);
         logStep(`작업 경로: ${targetPath}`);
       }
@@ -319,7 +330,7 @@ program
         await fs.ensureDir(metaDir);
         let sourceViteProjectRoot = mode === 'copy' ? cwd : null;
 
-        // inplace라면 step1 적용 전에 Vite baseline 스냅샷 자동 생성
+        // inplace라면 step1 적용 전에 Vite 원본 비교용 복사본 자동 생성
         // (step1이 package.json/scripts 등을 Next로 바꿔서 원본이 사라지기 때문)
         if (mode !== 'copy') {
           const resolvedTargetPath = path.resolve(targetPath);
@@ -328,9 +339,9 @@ program
           const baselineSnapshotRoot = path.join(parentDir, `${projectName}__nextify_snapshots`, 'vite-baseline');
           const exists = await fs.pathExists(baselineSnapshotRoot);
           if (!exists) {
-            logStep('[inplace] Vite baseline 스냅샷 생성 중...');
-            await cloneProject(targetPath, baselineSnapshotRoot);
-            logStep(`[inplace] Vite baseline 스냅샷 생성 완료: ${baselineSnapshotRoot}`);
+            await cloneProject(targetPath, baselineSnapshotRoot, {
+              silent: true,
+            });
           }
           sourceViteProjectRoot = baselineSnapshotRoot;
         }
@@ -437,24 +448,8 @@ program
 // =========================================================
 program
   .command('step6')
-  .description('6단계: 환경 변수 설정 & 의존성 갱신 가이드')
-  .action(async () => {
-    try {
-      // Step 6 실행
-      await runStep6(process.cwd());
-    } catch (error) {
-      console.error(chalk.red('\n❌ Step 6 오류 발생:'), error);
-      process.exit(1);
-    }
-  });
-
-// =========================================================
-// Command: Step 7
-// =========================================================
-program
-  .command('step7')
-  .description('7단계: next/image, next/font, Dynamic Import 적용 및 React 흔적 정리 (검증은 app/src/validation)')
-  .option('--skip-validation', '이 단계에서 타입 검증(validation) 호출 생략 — 이후 migrate-next validate 로 실행')
+  .description('6단계: Next.js 심화 변환')
+  .option('--skip-validation', '이 단계에서 타입 검증(validation) 호출 생략')
   .option('--no-typecheck-autofix', 'validation 단계: 결정론적 TypeScript 자동 수정 비활성화')
   .option('--no-typecheck-ai-fix', 'validation 단계: AI 잔여 빌드 에러 보정 비활성화 (GEMINI_API_KEY)')
   .option(
@@ -464,46 +459,56 @@ program
   )
   .action(async (options) => {
     try {
-      await runStep7(process.cwd(), {
+      const projectRoot = process.cwd();
+      await runAdvancedMigrationWithSession(projectRoot, {
         skipValidation: options.skipValidation,
         typecheckAutofix: options.typecheckAutofix,
         typecheckAiFix: options.typecheckAiFix,
         typecheckAiFixBudget: options.typecheckAiFixBudget,
       });
+      await printAdvancedNextSteps(projectRoot);
     } catch (error) {
-      console.error(chalk.red('\n❌ Step 7 오류 발생:'), error);
+      console.error(chalk.red('\n❌ Step 6 오류 발생:'), error);
       process.exit(1);
     }
   });
 
 // =========================================================
-// Command: Validation (TypeScript / tsc 파이프라인)
+// Command: Advanced
 // =========================================================
 program
-  .command('validate')
-  .description('타입 검사(tsc) + 결정론적 자동 수정 + (옵션) AI 보정 — 구현은 app/src/validation')
-  .option('--no-typecheck-autofix', '결정론적 TypeScript 자동 수정 비활성화 (기본: 활성화)')
-  .option('--no-typecheck-ai-fix', 'AI 잔여 에러 보정 비활성화 (GEMINI_API_KEY 필요)')
-  .option('--typecheck-ai-fix-budget <n>', 'AI 보정 최대 파일 수 (기본 5)', (v) => Number(v))
+  .command('advanced')
+  .description('Next.js 심화 변환 실행')
+  .option('--skip-validation', '이 단계에서 타입 검증(validation) 호출 생략')
+  .option('--no-typecheck-autofix', 'validation 단계: 결정론적 TypeScript 자동 수정 비활성화')
+  .option('--no-typecheck-ai-fix', 'validation 단계: AI 잔여 빌드 에러 보정 비활성화 (GEMINI_API_KEY)')
+  .option(
+    '--typecheck-ai-fix-budget <n>',
+    'validation 단계: AI 보정 최대 파일 수 (기본 5)',
+    (v) => Number(v),
+  )
   .action(async (options) => {
     try {
-      await runValidation(process.cwd(), {
-        autofix: options.typecheckAutofix,
-        aiFix: options.typecheckAiFix,
-        aiFixBudget: options.typecheckAiFixBudget,
+      const projectRoot = process.cwd();
+      await runAdvancedMigrationWithSession(projectRoot, {
+        skipValidation: options.skipValidation,
+        typecheckAutofix: options.typecheckAutofix,
+        typecheckAiFix: options.typecheckAiFix,
+        typecheckAiFixBudget: options.typecheckAiFixBudget,
       });
+      await printAdvancedNextSteps(projectRoot);
     } catch (error) {
-      console.error(chalk.red('\n❌ validate 오류 발생:'), error);
+      console.error(chalk.red('\n❌ advanced 오류 발생:'), error);
       process.exit(1);
     }
   });
 
 // =========================================================
-// Command: Steps (step1~step7 only)
+// Command: Steps (step1~step6 only)
 // =========================================================
 program
   .command('steps')
-  .description('step1~step7 순차 실행 (성능 레포트/AI 리뷰 제외)')
+  .description('step1~step6 순차 실행 (성능 레포트/AI 리뷰 제외)')
   .action(async () => {
     try {
       const projectRoot = process.cwd();
@@ -514,20 +519,32 @@ program
         ['step4', runStep4],
         ['step5', runStep5],
         ['step6', runStep6],
-        ['step7', runStep7],
       ];
 
       for (const [stepName, stepRunner] of stepEntries) {
         const partNum = stepName.replace('step', '');
         logSection(`Part ${partNum} (${stepName})`);
+        if (stepName === 'step6') {
+          try {
+            await createBaseMigrationSnapshot(projectRoot);
+          } catch (snapshotErr) {
+            logWarn(`심화 변환 전 비교용 복사본 생성 실패: ${snapshotErr?.message || snapshotErr}`);
+          }
+        }
         await stepRunner(projectRoot);
+        if (stepName === 'step6') {
+          await runAdvancedTypeScriptValidation(projectRoot);
+        }
       }
 
-      logSuccess('step1~step7 순차 실행 완료 (레포트/AI 리뷰 미실행).');
+      await ensureNextifyMeta(projectRoot, {
+        advancedCompleted: true,
+        advanced: { completedAt: new Date().toISOString() },
+      });
+      logSuccess('step1~step6 순차 실행 완료 (레포트/AI 리뷰 미실행).');
       logSection('필요 시 추가 실행');
-      logStep('타입 검증만 재실행: migrate-next validate');
-      logStep('성능 레포트: migrate-next report');
-      logStep('전체 오케스트레이터: migrate-next');
+      logInfo('성능 레포트: migrate-next report');
+      logInfo('기본 마이그레이션: migrate-next');
     } catch (error) {
       console.error(chalk.red('\n❌ steps 실행 중 오류 발생:'), error);
       process.exit(1);
@@ -540,7 +557,7 @@ program
 program
   .command('report')
   .description('성능 비교 레포트 생성 (레포트 명령으로 통합)')
-  .option('--run-step7', '레포트 생성 전에 Step7 최적화를 먼저 적용')
+  .option('--run-advanced', '레포트 생성 전에 Next.js 심화 변환을 먼저 적용')
   .option('--baseline <path>', 'Vite 원본 프로젝트 루트 경로 (메타가 없으면 필수)')
   .option('--output <path>', '생성할 마크다운 레포트 파일 경로 (기본: <projectRoot>/nextify-performance-report.md)')
   .option('--runs <number>', 'Lighthouse 측정 횟수 (기본 3)', (v) => Number(v), 3)
@@ -557,15 +574,8 @@ program
           ? Math.floor(options.warmupRuns)
           : 1;
 
-      if (options.runStep7) {
-        await runStep7(projectRoot, {
-          report: true,
-          baselineViteRoot,
-          outputPath,
-          lighthouseRuns,
-          warmupRuns,
-        });
-        return;
+      if (options.runAdvanced) {
+        await runAdvancedMigrationWithSession(projectRoot);
       }
 
       const { generatePerformanceReport } = require('./src/step7/performance-report.cjs');
@@ -648,7 +658,7 @@ program
           context,
         });
         spinner.stop();
-        printRelPathsBlock(chalk.green, '\n✅ 적용 완료', written);
+        printRelPathsBlock(chalk.green, '\n✔ 적용 완료', written);
         console.log('');
         return;
       }
@@ -706,17 +716,22 @@ program
 
       if (!sessionPath) {
         logError('재사용할 session.json을 찾지 못했습니다.');
-        logStep('먼저 `migrate-next` 또는 `migrate-next steps` 로 마이그레이션을 진행하거나, --session <path> 로 직접 지정하세요.');
+        logInfo('먼저 `migrate-next`로 마이그레이션을 진행하거나, --session <path>로 직접 지정하세요.');
         process.exit(1);
       }
 
-      logSection('Gemini CLI 코드 리뷰 (재사용)');
+      logSection('코드 리뷰 및 diff 확인');
       logStep(`세션 파일: ${sessionPath}`);
-      logStep('Nextify Review 확장 + Gemini CLI 가 이미 설치되어있습니다. 곧바로 리뷰를 시작합니다.');
-      logStep('  · 확장 미설치 시 패널이 안 보일 수 있습니다 → Marketplace `capstone0123.nextify-review` 설치.');
-      logStep('  · Gemini CLI 미설치 시 ENOENT 로 종료됩니다 → `npm install -g @google/gemini-cli` 후 재실행.');
-      logStep('리뷰는 view-only입니다. 진행 중 중단하려면 Ctrl+C를 누르세요.');
-      logStep('@파일경로를 붙여 넣어 해당 파일을 참조할 수 있습니다.');
+      logInfo('변경 전후 diff 창을 열고 Gemini CLI 리뷰를 시작합니다.');
+      logInfo('리뷰는 view-only이며, 파일은 자동 수정되지 않습니다.');
+      logInfo('진행 중 중단하려면 Ctrl+C를 누르세요.');
+      logInfo('@파일경로를 붙여 넣어 특정 파일을 Gemini에 참조시킬 수 있습니다.');
+      logStep('확장이 보이지 않으면 Marketplace에서 `capstone0123.nextify-review`를 설치하세요.');
+      logStep('Gemini CLI가 없다면 `npm install -g @google/gemini-cli` 후 다시 실행하세요.');
+
+      const sessionManifest = await fs.readJson(sessionPath);
+      await promptAndEnsureNextifyReviewExtension();
+      openFirstReviewableDiff(sessionManifest);
 
       const aiAbort = new AbortController();
       const onSigint = () => {
@@ -825,15 +840,6 @@ function tryAddFolderToCurrentWorkspace(folderAbsPath) {
   return { ok: false };
 }
 
-function printWorkspaceAddFallbackGuide(folderAbsPath) {
-  const abs = path.resolve(folderAbsPath);
-  const parentDir = path.dirname(abs);
-  logWarn('IDE에 결과 폴더를 자동으로 추가하지 못했습니다. (VS Code/Cursor CLI 가 PATH에 없거나 실행에 실패함)');
-  logStep('Nextify Review 패널 트리가 비면 다음 중 하나를 하세요:');
-  logStep(`1) 파일 → 작업 영역에 폴더 추가 → ${abs}`);
-  logStep(`2) 부모 폴더를 워크스페이스로 연 다음(예: ${parentDir}), 터미널에서 프로젝트 하위 폴더로 이동해 migrate-next 실행 — 터미널 세션은 그대로 유지됩니다.`);
-}
-
 /**
  * Nextify Review 확장 설치 여부를 확인하고, 필요 시 설치 후 패널에 포커스합니다.
  * `NEXTIFY_ASSUME_YES=1`이면 확인 없이 설치를 시도합니다.
@@ -887,16 +893,63 @@ async function promptAndEnsureNextifyReviewExtension() {
   }
 }
 
-/**
- * 마이그레이션 완료 후 공통 다음 단계 안내를 출력합니다.
- * @param {string} installCmd 패키지 매니저 설치 명령
- * @param {string|null} [reportPath] 성능 레포트 파일 경로 (있을 때만 표시)
- */
-function printNextSteps(installCmd, reportPath) {
-  logSection('다음 단계');
-  logStep(`${installCmd}  (의존성 설치)`);
-  logStep('마이그레이션된 프로젝트에서 빌드·실행을 확인하세요.');
-  if (reportPath) logStep(`성능 레포트 확인: ${reportPath}`);
+async function printBaseMigrationFinalGuide(projectRoot, mode = 'copy') {
+  await runEnvAndDependencyGuide(projectRoot);
+  logSection('추가 명령어');
+  if (mode === 'copy') {
+    logInfo('먼저 마이그레이션된 프로젝트 폴더로 이동하세요.');
+    console.log(chalk.gray(`    cd "${projectRoot}"`));
+  } else {
+    logInfo('현재 폴더에서 아래 명령어를 실행하세요.');
+  }
+  logInfo('migrate-next advanced  (Next.js 심화 변환)');
+  logInfo('migrate-next report    (성능 비교 레포트 생성)');
+  logInfo('migrate-next review    (diff 확인 및 AI 코드 리뷰)');
+}
+
+async function printAdvancedNextSteps(projectRoot) {
+  console.log(chalk.white('\n심화 변환 후 확인할 항목'));
+  await guideDependencyReset(projectRoot);
+  console.log(chalk.white('\n빌드 확인'));
+  console.log(chalk.gray('  마이그레이션된 프로젝트에서 빌드·실행을 다시 확인하세요.'));
+  logSection('추가 명령어');
+  logInfo('현재 마이그레이션된 프로젝트 폴더에서 아래 명령어를 실행하세요.');
+  logInfo('migrate-next report    (성능 비교 레포트 생성)');
+  logInfo('migrate-next review    (diff 확인 및 AI 코드 리뷰)');
+}
+
+async function runAdvancedTypeScriptValidation(projectRoot, options = {}) {
+  if (options.skipValidation === true) return;
+
+  logSection('TypeScript 검증');
+  await runValidation(projectRoot, {
+    autofix: options.typecheckAutofix !== false,
+    aiFix: options.typecheckAiFix !== false,
+    aiFixBudget: options.typecheckAiFixBudget,
+  });
+}
+
+async function runAdvancedMigrationWithSession(projectRoot, options = {}) {
+  const session = await createSnapshotReviewSession(projectRoot, 'step6', async (root) => {
+    try {
+      await createBaseMigrationSnapshot(root);
+    } catch (snapshotErr) {
+      logWarn(`심화 변환 전 비교용 복사본 생성 실패: ${snapshotErr?.message || snapshotErr}`);
+    }
+
+    await runStep6(root, options);
+    await runAdvancedTypeScriptValidation(root, options);
+    await ensureNextifyMeta(root, {
+      advancedCompleted: true,
+      advanced: { completedAt: new Date().toISOString() },
+    });
+  });
+
+  const changeCount = Array.isArray(session?.manifest?.changes) ? session.manifest.changes.length : 0;
+  if (changeCount > 0) {
+    logStep(`심화 변환 리뷰 세션 생성: ${session.manifestPath}`);
+  }
+  return session;
 }
 
 /**
@@ -954,9 +1007,9 @@ async function ensureOrchestratorMeta(cwd, targetPath, mode) {
     const baselineSnapshotRoot = path.join(parentDir, `${projectName}__nextify_snapshots`, 'vite-baseline');
     const exists = await fs.pathExists(baselineSnapshotRoot);
     if (!exists) {
-      logStep('[inplace] Vite baseline 스냅샷 생성 중...');
-      await cloneProject(targetPath, baselineSnapshotRoot);
-      logStep(`[inplace] Vite baseline 스냅샷 생성 완료: ${baselineSnapshotRoot}`);
+      await cloneProject(targetPath, baselineSnapshotRoot, {
+        silent: true,
+      });
     }
     sourceViteProjectRoot = baselineSnapshotRoot;
   }
@@ -982,56 +1035,8 @@ function summarizeChangeTypes(changes) {
   return summary;
 }
 
-function normalizeErrorLike(errorLike) {
-  if (errorLike instanceof Error) return errorLike;
-  if (typeof errorLike === 'string') return new Error(errorLike);
-  try {
-    return new Error(JSON.stringify(errorLike));
-  } catch {
-    return new Error(String(errorLike));
-  }
-}
-
-async function runPerformanceReportSafely(reportOptions) {
-  let capturedRuntimeError = null;
-  const onUncaughtException = (error) => {
-    capturedRuntimeError = normalizeErrorLike(error);
-  };
-  const onUnhandledRejection = (reason) => {
-    capturedRuntimeError = normalizeErrorLike(reason);
-  };
-
-  process.on('uncaughtException', onUncaughtException);
-  process.on('unhandledRejection', onUnhandledRejection);
-
-  const reportPromise = generatePerformanceReport(reportOptions);
-  let watcherId;
-  try {
-    await Promise.race([
-      reportPromise,
-      new Promise((_, reject) => {
-        watcherId = setInterval(() => {
-          if (capturedRuntimeError) {
-            clearInterval(watcherId);
-            reject(capturedRuntimeError);
-          }
-        }, 100);
-      }),
-    ]);
-    if (watcherId) clearInterval(watcherId);
-    return { success: true };
-  } catch (error) {
-    if (watcherId) clearInterval(watcherId);
-    return { success: false, error: normalizeErrorLike(error) };
-  } finally {
-    process.off('uncaughtException', onUncaughtException);
-    process.off('unhandledRejection', onUnhandledRejection);
-  }
-}
-
 async function runDefaultOrchestrator() {
   const cwd = process.cwd();
-  const orchestratorStartedAt = Date.now();
 
   // 1) detect & validate project type
   const pm = detectPackageManager(cwd);
@@ -1096,32 +1101,20 @@ async function runDefaultOrchestrator() {
       targetPath = path.join(parentDir, cleanedPath);
     }
 
-    await cloneProject(cwd, targetPath);
+    await cloneProject(cwd, targetPath, {
+      startMessage: '작업용 프로젝트를 복사하는 중...',
+      successMessage: `작업용 프로젝트 복사 완료: ${targetPath}`,
+      failMessage: '작업용 프로젝트 복사 실패',
+    });
     process.chdir(targetPath);
     logStep(`작업 경로: ${targetPath}`);
 
-    const wsAdd = tryAddFolderToCurrentWorkspace(targetPath);
-    if (wsAdd.ok) {
-      logStep(`현재 창 워크스페이스에 복사본 폴더를 추가했습니다. (${wsAdd.command})`);
-    } else if (!wsAdd.skipped) {
-      printWorkspaceAddFallbackGuide(targetPath);
-    }
+    tryAddFolderToCurrentWorkspace(targetPath);
   }
 
   // 이전 실행에서 남아있는 step 아티팩트를 정리합니다.
   await cleanupStaleStepArtifacts(targetPath);
   await ensureOrchestratorMeta(cwd, targetPath, mode);
-
-  // step1~6은 기본 마이그레이션, step7은 "Next.js 심화 변환"으로 사용자 선택입니다.
-  // 무조건 적용되는 것이 아니라, 트레이드오프(코드 구조 변경)를 사용자가 인지한 뒤 결정합니다.
-  const { runFinalOptimize } = await inquirer.prompt([
-    {
-      type: 'confirm',
-      name: 'runFinalOptimize',
-      message: 'Next.js 심화 변환(next/image, next/font, Dynamic Import 등)을 적용하시겠습니까?',
-      default: true,
-    },
-  ]);
 
   const stepEntries = [
     ['step1', runStep1],
@@ -1129,196 +1122,49 @@ async function runDefaultOrchestrator() {
     ['step3', runStep3],
     ['step4', runStep4],
     ['step5', runStep5],
-    ['step6', runStep6],
   ];
-  if (runFinalOptimize) {
-    stepEntries.push(['step7', runStep7]);
-  }
 
-  // step7 적용 여부에 따라 최종 리뷰 세션 디렉터리도 분기합니다.
-  // (확장은 step 번호가 가장 큰 session.json 을 자동으로 선택)
-  const finalSnapshotStep = runFinalOptimize ? 'step7' : 'step6';
-
-  const finalReviewSession = await createSnapshotReviewSession(targetPath, finalSnapshotStep, async (projectRoot) => {
+  const finalReviewSession = await createSnapshotReviewSession(targetPath, 'step5', async (projectRoot) => {
     for (const [stepName, stepRunner] of stepEntries) {
       const partNum = stepName.replace('step', '');
       logSection(`Part ${partNum} (${stepName})`);
-      // step7 시작 직전(즉 step1~6 결과 시점)에서 성능 비교용 스냅샷을 생성해 둡니다.
-      // 이렇게 하지 않으면 generatePerformanceReport 시점에 만들어져 step7 결과를 복사하게 되어
-      // step1~6 vs step1~7 비교가 사실상 동일 코드 비교가 되어 버립니다.
-      if (stepName === 'step7') {
-        try {
-          logStep('step7 적용 전 스냅샷을 생성합니다. (step1~6 결과 보존)');
-          await createPreStep7Snapshot(projectRoot);
-        } catch (snapshotErr) {
-          logWarn(`step7 사전 스냅샷 생성 실패: ${snapshotErr?.message || snapshotErr}`);
-          logStep('성능 레포트의 step1~6 비교 결과가 step1~7과 동일해질 수 있습니다.');
-        }
-      }
-      if (stepName === 'step6') {
-        const expectedReportPath = path.join(projectRoot, 'nextify-performance-report.md');
-        await stepRunner(projectRoot, { reportPath: expectedReportPath });
-      } else {
-        await stepRunner(projectRoot);
-      }
+      await stepRunner(projectRoot);
+    }
+
+    logSection('TypeScript 검증');
+    await runValidation(projectRoot);
+
+    try {
+      const snapshotPath = await createBaseMigrationSnapshot(projectRoot);
+      await ensureNextifyMeta(projectRoot, {
+        baseMigrationCompleted: true,
+        baseMigrationCompletedAt: new Date().toISOString(),
+        baseMigrationSnapshotRoot: snapshotPath,
+        advancedCompleted: false,
+      });
+      logSuccess('성능 레포트 비교용 데이터가 생성되었습니다.');
+      logStep('생성된 폴더: __nextify_snapshots');
+      logStep('이 폴더는 migrate-next report에서 사용됩니다.');
+    } catch (snapshotErr) {
+      logWarn(`비교용 복사본 생성 실패: ${snapshotErr?.message || snapshotErr}`);
+      logStep('성능 레포트에서 기본 마이그레이션 비교 대상이 현재 상태로 대체될 수 있습니다.');
     }
   });
 
   const { manifest, manifestPath } = finalReviewSession;
-  const finalStepLabel = runFinalOptimize ? 'step1~step7' : 'step1~step6';
+  const finalStepLabel = 'step1~step5';
 
   if (!manifestPath || !Array.isArray(manifest?.changes) || manifest.changes.length === 0) {
     logSuccess(`${finalStepLabel} 완료: 최종 변경 없음`);
-    logStep('변경 추적 결과가 비어 성능 레포트·코드 리뷰 단계는 건너뜁니다. 필요하면 `migrate-next report` 또는 전체 플로우를 다시 확인하세요.');
-    const installCmd = getInstallCommand(pm);
-    printNextSteps(installCmd, null);
+    await printBaseMigrationFinalGuide(targetPath, mode);
     return;
   }
 
   const typeSummary = summarizeChangeTypes(manifest.changes);
   logSuccess(`${finalStepLabel} 완료 (변경 ${manifest.changes.length}개)`);
   logStep(`created ${typeSummary.create}  modified ${typeSummary.modify}  deleted ${typeSummary.delete}`);
-
-  // 1) 성능 레포트 생성 여부 확인
-  let reportPath = null;
-  let reportResult = { success: false };
-  if (runFinalOptimize) {
-    const { doReport } = await inquirer.prompt([
-      {
-        type: 'confirm',
-        name: 'doReport',
-        message: '성능 비교 레포트(Vite vs Next.js)를 생성하시겠습니까? (Lighthouse 측정으로 수 분 소요)',
-        default: true,
-      },
-    ]);
-
-    if (doReport) {
-      logSection('성능 레포트 생성');
-      reportPath = path.join(targetPath, 'nextify-performance-report.md');
-      // step7 진입 직전에 미리 만들어 둔 스냅샷 경로를 명시적으로 전달합니다.
-      // (그렇지 않으면 generatePerformanceReport 가 이 시점에 다시 createPreStep7Snapshot 을 호출하는데,
-      //  이미 step7 가 끝난 상태이므로 snapshot 이 step7 결과의 복사본이 되어 비교가 무의미해집니다.)
-      const preStep7SnapshotRoot = path.join(
-        path.dirname(targetPath),
-        `${path.basename(targetPath)}__nextify_snapshots`,
-        'pre-step7',
-      );
-      reportResult = await runPerformanceReportSafely({
-        projectRoot: targetPath,
-        outputMarkdownPath: reportPath,
-        preStep7Root: preStep7SnapshotRoot,
-        startedAt: orchestratorStartedAt,
-      });
-      if (!reportResult.success) {
-        logWarn(`성능 레포트 생성에 실패했습니다: ${reportResult.error.message}`);
-        logStep('마이그레이션 결과는 유지됩니다. 필요 시 `migrate-next report`로 재시도하세요.');
-      }
-    } else {
-      logStep('성능 레포트 생성을 건너뜁니다. 필요 시 `migrate-next report`로 생성할 수 있습니다.');
-    }
-  } else {
-    logStep('Next.js 심화 변환을 건너뛰어 성능 레포트 단계도 생략합니다. 필요 시 `migrate-next step7` 후 `migrate-next report`로 생성할 수 있습니다.');
-  }
-
-  // 2) 코드 리뷰 여부 확인
-  console.log(chalk.gray('──────────────────────────────────────────────────'));
-  console.log(chalk.white('코드 리뷰 안내'));
-  console.log(chalk.white('· Nextify Review 패널에서 파일을 클릭하면 변경 전후 코드를 비교할 수 있습니다.'));
-  console.log(chalk.white('· 변경 전·후 파일 경로를 모두 Gemini에 붙여 넣으면 해당 파일에 대해 질문할 수 있습니다.'));
-  console.log(chalk.white('· Gemini는 코드 수정을 제안만 합니다. 실제 수정은 직접 파일을 열어서 하세요.'));
-  console.log(chalk.white('· 종료하려면 Ctrl+C를 누르세요.'));
-  console.log(chalk.gray('──────────────────────────────────────────────────'));
-  const { useReview } = await inquirer.prompt([
-    {
-      type: 'confirm',
-      name: 'useReview',
-      message: '변경된 파일을 확인하고 Gemini로 코드 리뷰하시겠습니까?',
-      default: true,
-    },
-  ]);
-
-  if (!useReview) {
-    logSuccess('마이그레이션 완료.');
-    logStep('나중에 리뷰만 다시 실행하려면: `migrate-next review`');
-    const installCmd = getInstallCommand(pm);
-    printNextSteps(installCmd, reportResult.success ? reportPath : null);
-    return;
-  }
-
-  // 3) 코드 리뷰 진행
-  await promptAndEnsureNextifyReviewExtension();
-
-  logSection('코드 리뷰');
-  logStep('Nextify Review 패널에서 파일을 클릭해 diff를 확인하세요.');
-  logStep('BEFORE/AFTER 경로 복사 후 Gemini CLI 에 @경로 형태로 붙여 넣을 수 있습니다.');
-
-  logSection('Gemini CLI 리뷰');
-  try {
-    const setup = await ensureGeminiCliReady({
-      pm,
-      cwd: targetPath,
-      onInfo: (msg) => logStep(msg),
-    });
-    if (setup.installedNow) {
-      logSuccess('Gemini CLI 자동 설치 및 검증 완료.');
-    } else {
-      logStep('Gemini CLI가 이미 설치되어 있습니다.');
-    }
-  } catch (err) {
-    const fallbackInstall =
-      pm === 'yarn'
-        ? 'yarn global add @google/gemini-cli'
-        : pm === 'pnpm'
-          ? 'pnpm add -g @google/gemini-cli'
-          : 'npm install -g @google/gemini-cli';
-    logError('Gemini CLI 자동 설치에 실패했습니다.');
-    if (err?.lastError?.message) {
-      logStep(`원인: ${err.lastError.message}`);
-    } else if (err?.message) {
-      logStep(`원인: ${err.message}`);
-    }
-    logWarn(`수동 설치 후 다시 실행하세요: ${fallbackInstall}`);
-    throw err;
-  }
-
-  logStep('리뷰는 view-only입니다. 진행 중 중단하려면 Ctrl+C를 누르세요.');
-  logStep('@파일경로를 붙여 넣어 해당 파일을 참조할 수 있습니다.');
-  logStep('Nextify Review 패널에서 diff 확인 및 BEFORE/AFTER 경로 복사 가능.');
-
-  const aiAbort = new AbortController();
-  const onSigint = () => {
-    if (!aiAbort.signal.aborted) {
-      process.stdout.write('\n');
-      logWarn('Ctrl+C 감지: 현재 Gemini CLI 리뷰를 중단합니다.');
-      aiAbort.abort();
-    }
-  };
-
-  process.on('SIGINT', onSigint);
-  try {
-    await runAiReviewSessionStream({
-      sessionPath: manifestPath,
-      signal: aiAbort.signal,
-      transport: 'cli',
-      mode: 'interactive-seeded',
-      model: process.env.NEXTIFY_GEMINI_CLI_MODEL || 'gemini-2.5-flash-lite',
-      workingDirectory: targetPath,
-      onChunk: (t) => process.stdout.write(t),
-    });
-  } catch (err) {
-    if (err?.code === 'ENOENT') {
-      logError('Gemini CLI를 찾을 수 없습니다.');
-      logWarn('Gemini CLI를 설치하고 `gemini` 명령이 PATH에서 실행되는지 확인하세요.');
-    }
-    throw err;
-  } finally {
-    process.off('SIGINT', onSigint);
-  }
-
-  logSuccess('코드 리뷰 완료.');
-
-  const installCmd = getInstallCommand(pm);
-  printNextSteps(installCmd, reportResult.success ? reportPath : null);
+  logSuccess('기본 마이그레이션 완료.');
+  await printBaseMigrationFinalGuide(targetPath, mode);
 }
 
 // Only run default orchestrator when user calls `migrate-next` with no subcommand.

--- a/app/src/step1/index.cjs
+++ b/app/src/step1/index.cjs
@@ -15,8 +15,8 @@ const chalk = require('chalk');
  * Step 1 메인 실행 함수
  */
 async function runStep1(projectRoot) {
-  console.log(chalk.gray('────────────────────────────────────────────────────────────'));
-  console.log(chalk.blue.bold('[1단계] 프로젝트 환경 설정을 시작합니다…'));
+  console.log(chalk.gray('──────────────────────────────────────────────────────────────────────────────────────────────────────'));
+  console.log(chalk.blue.bold('[1단계] 프로젝트 환경 설정을 시작합니다.'));
 
   try {
     // 0. (사전) 워처 친화 설정 — .ai-migration/, node_modules/ 등을 .vscode/settings.json에서 제외해
@@ -29,23 +29,23 @@ async function runStep1(projectRoot) {
     }
 
     // 1. package.json 수정
-    console.log('  → package.json에 Next.js 관련 패키지와 실행 스크립트를 추가하는 중…');
+    console.log('  → package.json에 Next.js 관련 패키지와 실행 스크립트를 추가하는 중.');
     await updatePackageJson(projectRoot);
     console.log('  ✔ package.json 업데이트 완료\n');
 
     // 2. 설정 파일 업데이트 및 정리
-    console.log('  → Vite 전용 설정 파일을 제거하고 next.config.mjs 및 .gitignore를 설정하는 중…');
+    console.log('  → Vite 전용 설정 파일을 제거하고 next.config.mjs 및 .gitignore를 설정하는 중.');
     await setupConfigFiles(projectRoot);
     console.log('  ✔ 설정 파일 정리 및 생성 완료\n');
 
     // 3. vite.config.ts 설정 마이그레이션
-    console.log('  → vite.config.ts 설정을 분석해 Next.js 형식으로 변환하는 중…');
+    console.log('  → vite.config.ts 설정을 분석해 Next.js 형식으로 변환하는 중.');
     await migrateViteConfig(projectRoot);
     await migrateViteDefine(projectRoot);
     console.log('  ✔ Vite 설정 변환 완료 (vite.config.ts 제거됨)\n');
 
     // 4. TypeScript 설정 정리
-    console.log('  → tsconfig.app.json의 컴파일러 옵션을 tsconfig.json으로 이관하고 Next.js 기준으로 정리하는 중…');
+    console.log('  → tsconfig.app.json의 컴파일러 옵션을 tsconfig.json으로 이관하고 Next.js 기준으로 정리하는 중.');
     await updateTsConfig(projectRoot);
     console.log('  ✔ TypeScript 설정 통합 완료 (tsconfig.app.json 제거됨)');
 
@@ -53,17 +53,7 @@ async function runStep1(projectRoot) {
     //    tsconfig.exclude / .gitignore 에서 제외해 사용자 빌드가
     //    부분 변환 스냅샷까지 type-check 하면서 깨지는 사고를 차단한다.
     try {
-      const result = await ensureNextifyExcludes(projectRoot);
-      if (result.tsconfig.updated) {
-        console.log(
-          chalk.gray('   🛡️  tsconfig.json exclude 보강: .ai-migration, __nextify_snapshots'),
-        );
-      }
-      if (result.gitignore.updated && result.gitignore.addedLines.length > 0) {
-        console.log(
-          chalk.gray(`   🛡️  .gitignore 보강: ${result.gitignore.addedLines.join(', ')}`),
-        );
-      }
+      await ensureNextifyExcludes(projectRoot);
     } catch {
       // 안전망 자체의 실패는 마이그레이션을 막지 않는다.
     }

--- a/app/src/step2/index.cjs
+++ b/app/src/step2/index.cjs
@@ -9,17 +9,17 @@ const chalk = require('chalk');
  * Step 2 메인 실행 함수
  */
 async function runStep2(projectRoot) {
-  console.log(chalk.gray('────────────────────────────────────────────────────────────'));
-  console.log(chalk.blue.bold('[2단계] 앱 구조 변환을 시작합니다…'));
+  console.log(chalk.gray('──────────────────────────────────────────────────────────────────────────────────────────────────────'));
+  console.log(chalk.blue.bold('[2단계] 앱 구조 변환을 시작합니다.'));
 
   try {
     // 1. 레이아웃 생성 (index.html -> app/layout.tsx)
-    console.log('  → index.html을 분석해 Next.js용 루트 레이아웃(layout.tsx)으로 변환하는 중…');
+    console.log('  → index.html을 분석해 Next.js용 루트 레이아웃(layout.tsx)으로 변환하는 중.');
     await generateLayout(projectRoot);
     console.log('  ✔ layout.tsx 생성 완료 (HTML → JSX 변환, Vite 전용 스크립트 제거됨)\n');
 
     // 2. Provider 마이그레이션 (React Query, ThemeProvider 등 -> src/app/providers.tsx)
-    console.log('  → main.tsx·App.tsx에서 Provider 컴포넌트를 탐색해 src/app/providers.tsx로 통합하는 중…');
+    console.log('  → main.tsx·App.tsx에서 Provider 컴포넌트를 탐색해 src/app/providers.tsx로 통합하는 중.');
     await migrateProviders(projectRoot);
     console.log('  ✔ providers.tsx 생성 완료 (layout.tsx에 <Providers> 적용됨)');
 

--- a/app/src/step3/index.cjs
+++ b/app/src/step3/index.cjs
@@ -10,27 +10,27 @@ const chalk = require('chalk');
  * Step 3 메인 실행 함수
  */
 async function runStep3(projectRoot) {
-  console.log(chalk.gray('────────────────────────────────────────────────────────────'));
-  console.log(chalk.blue.bold('[3단계] 라우팅 구조 변환을 시작합니다…'));
+  console.log(chalk.gray('──────────────────────────────────────────────────────────────────────────────────────────────────────'));
+  console.log(chalk.blue.bold('[3단계] 라우팅 구조 변환을 시작합니다.'));
 
   try {
     // 1. Route 마이그레이션 (page.tsx, layout.tsx 생성)
-    console.log('  → React Router의 Route 구조를 분석해 Next.js 폴더·파일 구조로 변환하는 중…');
+    console.log('  → React Router의 Route 구조를 분석해 Next.js 폴더·파일 구조로 변환하는 중.');
     await migrateRoutes(projectRoot);
     console.log('  ✔ Route 구조 변환 완료\n');
 
     // 2. Link 마이그레이션
-    console.log('  → React Router의 link·hook을 Next.js 방식으로 교체하는 중…');
+    console.log('  → React Router의 link·hook을 Next.js 방식으로 교체하는 중.');
     await migrateLinks(projectRoot);
     console.log('  ✔ link·hook 교체 완료\n');
 
     // 3. Outlet 마이그레이션
-    console.log('  → React Router의 Outlet을 Next.js children 구조로 변환하는 중…');
+    console.log('  → React Router의 Outlet을 Next.js children 구조로 변환하는 중.');
     await migrateOutlets(projectRoot);
     console.log('  ✔ Outlet 변환 완료\n');
 
     // 4. 메타데이터 마이그레이션 실행
-    console.log('  → Helmet·Head 태그를 Next.js Metadata API로 변환하는 중…');
+    console.log('  → Helmet·Head 태그를 Next.js Metadata API로 변환하는 중.');
     await migrateMetadata(projectRoot);
     console.log('  ✔ Metadata 변환 완료');
 

--- a/app/src/step4/index.cjs
+++ b/app/src/step4/index.cjs
@@ -10,22 +10,22 @@ const chalk = require('chalk');
  * Step 4 메인 실행 함수
  */
 async function runStep4(projectRoot) {
-  console.log(chalk.gray('────────────────────────────────────────────────────────────'));
-  console.log(chalk.blue.bold('[4단계] 스타일 및 리소스 마이그레이션을 시작합니다…'));
+  console.log(chalk.gray('──────────────────────────────────────────────────────────────────────────────────────────────────────'));
+  console.log(chalk.blue.bold('[4단계] 스타일 및 리소스 마이그레이션을 시작합니다.'));
 
   try {
     // Global CSS 마이그레이션
-    console.log('  → 전역 CSS 파일을 src/app/global.css로 통합하는 중…');
+    console.log('  → 전역 CSS 파일을 src/app/global.css로 통합하는 중.');
     await migrateGlobalCss(projectRoot);
     console.log('  ✔ Global CSS 통합 완료\n');
 
     // 정적 리소스 마이그레이션
-    console.log('  → 정적 리소스를 public 폴더로 이동하고 참조 경로를 수정하는 중…');
+    console.log('  → 정적 리소스를 public 폴더로 이동하고 참조 경로를 수정하는 중.');
     await migrateStaticResources(projectRoot);
     console.log('  ✔ 정적 리소스 이동 완료\n');
 
     // Tailwind CSS 및 Styled Components 마이그레이션
-    console.log('  → Tailwind·styled-components 설정을 Next.js에 맞게 업데이트하는 중…');
+    console.log('  → Tailwind·styled-components 설정을 Next.js에 맞게 업데이트하는 중.');
     await migrateTailwindAndStyled(projectRoot);
     console.log('  ✔ 스타일 라이브러리 설정 완료');
 

--- a/app/src/step5/index.cjs
+++ b/app/src/step5/index.cjs
@@ -9,19 +9,19 @@ const chalk = require('chalk');
  * Step 5 메인 실행 함수
  */
 async function runStep5(projectRoot) {
-  console.log(chalk.gray('────────────────────────────────────────────────────────────'));
-  console.log(chalk.blue.bold('[5단계] 서버·클라이언트 호환성 작업을 시작합니다…'));
+  console.log(chalk.gray('──────────────────────────────────────────────────────────────────────────────────────────────────────'));
+  console.log(chalk.blue.bold('[5단계] 서버·클라이언트 호환성 작업을 시작합니다.'));
 
   try {
-    console.log('  → 클라이언트 전용 컴포넌트를 판별해 "use client" 지시문을 추가하는 중…');
+    console.log('  → 클라이언트 전용 컴포넌트를 판별해 "use client" 지시문을 추가하는 중.');
     await migrateUseClient(projectRoot);
     console.log('  ✔ "use client" 추가 완료\n');
 
-    console.log('  → 브라우저 전용 API 사용 코드를 탐색하는 중…');
+    console.log('  → 브라우저 전용 API 사용 코드를 탐색하는 중.');
     await migrateBrowserAPIs(projectRoot);
     console.log('  ✔ 브라우저 API 호환 처리 완료\n');
 
-    console.log('  → Zustand 스토어를 분석해 SSR 안전 구조로 변환하는 중…');
+    console.log('  → Zustand 스토어를 분석해 SSR 안전 구조로 변환하는 중.');
     const result = await migrateZustandStores(projectRoot);
     console.log('  ✔ Zustand 스토어 변환 완료');
 

--- a/app/src/step6/env-guide.cjs
+++ b/app/src/step6/env-guide.cjs
@@ -19,7 +19,8 @@ async function guideEnvMigration(projectRoot) {
   const envFiles = await findEnvFiles(projectRoot);
   const viteEnvVars = await findViteEnvVariables(projectRoot);
 
-  console.log(chalk.white('환경 변수 설정'));
+  console.log(chalk.white('\n마이그레이션 후 확인할 항목'));
+  console.log(chalk.white('\n환경 변수 확인'));
 
   // ① 파일명 변경 안내
   console.log(chalk.white('  ① 환경 변수 파일명 확인'));
@@ -55,12 +56,12 @@ async function guideEnvMigration(projectRoot) {
     if (hasEnvLocal) {
       console.log(chalk.green('    ✔ .gitignore에 .env.local이 이미 포함되어 있습니다.'));
     } else {
-      console.log(chalk.white('    .env.local이 Git에 올라가지 않도록 .gitignore에 추가하세요:'));
+      console.log(chalk.white('    필요하면 .env.local이 Git에 올라가지 않도록 .gitignore에 추가하세요:'));
       console.log(chalk.gray('      .env.local'));
       console.log(chalk.gray('      .env*.local'));
     }
   } else {
-    console.log(chalk.white('    .gitignore 파일을 만들고 아래 내용을 추가하세요:'));
+    console.log(chalk.white('    필요하면 .gitignore 파일을 만들고 아래 내용을 추가하세요:'));
     console.log(chalk.gray('      .env.local'));
     console.log(chalk.gray('      .env*.local'));
   }
@@ -187,11 +188,12 @@ async function guideDependencyReset(projectRoot) {
   const lockFile = getLockFileName(pm);
   const installCmd = getInstallCommand(pm);
 
-  console.log(chalk.white('의존성 재설치'));
+  console.log(chalk.white('\n의존성 재설치'));
+  console.log(chalk.white('  아래 순서대로 의존성을 다시 설치하세요.'));
 
   // ① 기존 모듈 제거
   console.log(chalk.white('  ① 기존 node_modules 삭제'));
-  console.log(chalk.gray('    Vite 환경의 패키지가 남아 있어 충돌할 수 있습니다. 삭제 후 재설치하세요.'));
+  console.log(chalk.gray('    Vite 환경의 패키지가 남아 있어 충돌할 수 있습니다. 먼저 삭제하세요.'));
   console.log(chalk.gray(`    · macOS / Linux:  rm -rf node_modules ${lockFile}`));
   console.log(chalk.gray(`    · Windows (PowerShell):  Remove-Item -Recurse -Force node_modules, ${lockFile}`));
 

--- a/app/src/step6/index.cjs
+++ b/app/src/step6/index.cjs
@@ -1,23 +1,13 @@
 // src/step6/index.cjs
-// Step 6: 환경 변수 설정 & 의존성 갱신 가이드
+// Step 6: Next.js 심화 변환
 
-const { runEnvAndDependencyGuide } = require('./env-guide.cjs');
-const chalk = require('chalk');
+const { runAdvancedMigration } = require('../step7/index.cjs');
 
 /**
- * Step 6 메인 실행 함수
+ * Step 6 메인 실행 함수: Next.js 심화 변환을 실행한다.
  */
 async function runStep6(projectRoot, options = {}) {
-  console.log(chalk.gray('────────────────────────────────────────────────────────────'));
-  console.log(chalk.blue.bold('[6단계] 환경 변수 및 의존성 설정 안내'));
-
-  try {
-    await runEnvAndDependencyGuide(projectRoot, { reportPath: options.reportPath });
-    console.log(chalk.green.bold('[6단계] 완료 — 위 안내에 따라 설정을 완료하세요.'));
-  } catch (error) {
-    console.error(chalk.red.bold('파트 6 오류 발생:'), error);
-    throw error;
-  }
+  return runAdvancedMigration(projectRoot, options);
 }
 
 module.exports = { runStep6 };

--- a/app/src/step7/dynamic-import-migrator.cjs
+++ b/app/src/step7/dynamic-import-migrator.cjs
@@ -263,13 +263,7 @@ async function optimizeDynamicImport(projectRoot) {
     if (fs.existsSync(srcDir)) {
       const tsxFiles = await collectTsxRelPaths(projectRoot, srcDir);
       if (tsxFiles.length > 0) {
-        const { changedFiles, removedTargets } = await sweepAfterAiApply(projectRoot, tsxFiles);
-        if (changedFiles.length > 0) {
-          const ssrFixes = removedTargets.filter((t) => t.startsWith('ssr:false@'));
-          if (ssrFixes.length > 0) {
-            console.log(`   🧹 Server Component 에서 dynamic({ ssr: false }) 의 ssr:false ${ssrFixes.length}건 제거됨`);
-          }
-        }
+        await sweepAfterAiApply(projectRoot, tsxFiles);
       }
     }
   } catch (err) {

--- a/app/src/step7/index.cjs
+++ b/app/src/step7/index.cjs
@@ -1,5 +1,5 @@
 // src/step7/index.cjs
-// Step 7: next/image 적용, next/font 적용, Dynamic Import 적용 및 남겨둔 React 흔적 정리
+// Next.js 심화 변환: next/image, next/font, Dynamic Import 적용 및 남겨둔 React 흔적 정리
 
 const { applyNextImage } = require('./next-image-migrator.cjs');
 const { applyNextFont } = require('./next-font-migrator.cjs');
@@ -7,66 +7,40 @@ const { optimizeDynamicImport } = require('./dynamic-import-migrator.cjs');
 const { cleanReactTrace } = require('./react-trace-cleaner.cjs');
 const { minimizeUseClientForBundle } = require('./useclient-minimizer.cjs');
 const { optimizeDataFetchingPlacement } = require('./data-fetch-migrator.cjs');
-const { generatePerformanceReport, createPreStep7Snapshot } = require('./performance-report.cjs');
-const { runValidation } = require('../validation/index.cjs');
-const { stripImportExtensions } = require('../utils/strip-import-extensions.cjs');
 const { stripRouterLeakInProviders } = require('../utils/strip-react-router-leak.cjs');
 const { pruneUnusedAssetConsts } = require('../utils/prune-unused-asset-consts.cjs');
 const { polyfillUseLocation } = require('../utils/polyfill-uselocation.cjs');
 const chalk = require('chalk');
-const path = require('path');
 
 /**
- * Step 7 메인 실행 함수
+ * Next.js 심화 변환 실행 함수
  */
-async function runStep7(projectRoot, options = {}) {
+async function runAdvancedMigration(projectRoot, options = {}) {
   try {
-    // report-only 모드: 마이그레이션을 다시 돌리지 않고 레포트만 생성
-    if (options.reportOnly) {
-      const outputPath = options.outputPath || path.join(projectRoot, 'nextify-performance-report.md');
-      await generatePerformanceReport({
-        projectRoot,
-        baselineViteRoot: options.baselineViteRoot,
-        preStep7Root: options.preStep7Root,
-        outputMarkdownPath: outputPath,
-        lighthouseRuns: options.lighthouseRuns,
-        warmupRuns: options.warmupRuns,
-      });
-      return;
-    }
+    console.log(chalk.gray('──────────────────────────────────────────────────────────────────────────────────────────────────────'));
+    console.log(chalk.blue.bold('[6단계] Next.js 심화 변환을 시작합니다.'));
 
-    // Step7 적용 전 백업 (step1~6 결과물 보존)
-    if (options.report) {
-      console.log(chalk.gray('────────────────────────────────────────────────────────────'));
-      console.log('· step7(최적화) 적용 전 프로젝트를 백업합니다. (step1~6 결과 보존)');
-      const snapshotPath = await createPreStep7Snapshot(projectRoot);
-      console.log(`  ✔ 백업 완료: ${snapshotPath}`);
-    }
-
-    console.log(chalk.gray('────────────────────────────────────────────────────────────'));
-    console.log(chalk.blue.bold('[7단계] Next.js 성능 최적화를 시작합니다…'));
-
-    console.log('  → 이미지를 next/image로 교체해 로딩 성능을 개선하는 중…');
+    console.log('  → 이미지를 next/image로 교체해 로딩 성능을 개선하는 중.');
     await applyNextImage(projectRoot);
     console.log('  ✔ next/image 적용 완료\n');
 
-    console.log('  → Google Fonts·로컬 폰트를 next/font로 전환하는 중…');
+    console.log('  → Google Fonts·로컬 폰트를 next/font로 전환하는 중.');
     await applyNextFont(projectRoot);
     console.log('  ✔ next/font 전환 완료\n');
 
-    console.log('  → 클라이언트 데이터 패칭 코드를 탐색하는 중…');
+    console.log('  → 클라이언트 데이터 패칭 코드를 탐색하는 중.');
     await optimizeDataFetchingPlacement(projectRoot);
     console.log('  ✔ 데이터 패칭 위치 최적화 완료\n');
 
-    console.log('  → "use client" 범위를 분석해 불필요한 지시문을 제거하는 중…');
+    console.log('  → "use client" 범위를 분석해 불필요한 지시문을 제거하는 중.');
     await minimizeUseClientForBundle(projectRoot);
     console.log('  ✔ "use client" 최소화 완료\n');
 
-    console.log('  → 무거운 컴포넌트를 Dynamic Import로 분리해 초기 번들을 줄이는 중…');
+    console.log('  → 무거운 컴포넌트를 Dynamic Import로 분리해 초기 번들을 줄이는 중.');
     await optimizeDynamicImport(projectRoot);
     console.log('  ✔ Dynamic Import 적용 완료\n');
 
-    console.log('  → 마이그레이션 과정에서 남은 React·Vite 파일과 패키지를 정리하는 중…');
+    console.log('  → 마이그레이션 과정에서 남은 React·Vite 파일과 패키지를 정리하는 중.');
     await cleanReactTrace(projectRoot);
     console.log('  ✔ 잔여 파일·패키지 정리 완료\n');
 
@@ -95,14 +69,7 @@ async function runStep7(projectRoot, options = {}) {
     //   `{ pathname: '', state: {} as any, ... } as any` 로 치환해 빌드를 통과시킨다.
     //   (full-lossy: state 데이터 의미는 손실되지만 빌드는 안전.)
     try {
-      const polyResult = await polyfillUseLocation(projectRoot);
-      if (polyResult.totalReplaced > 0) {
-        console.log(
-          chalk.gray(
-            `   🛡️  useLocation() 폴백 ${polyResult.totalReplaced}건 (${polyResult.changedFiles.length}개 파일)`,
-          ),
-        );
-      }
+      await polyfillUseLocation(projectRoot);
     } catch (polyErr) {
       console.log(
         chalk.gray(`   ⚠️  useLocation 폴백(무시): ${polyErr?.message || polyErr}`),
@@ -111,76 +78,25 @@ async function runStep7(projectRoot, options = {}) {
 
     // 사용처 0 인 asset const 결정론적 제거
     // - step4 가 `import X from '...svg'` → `const X = '/assets/...svg';` 로 바꾼 뒤
-    //   step7/next-image-migrator 가 `<img src={X}>` 를 리터럴로 인라이닝하면
+    //   next-image-migrator 가 `<img src={X}>` 를 리터럴로 인라이닝하면
     //   X 가 죽은 변수로 남아 `next build` 의 type-check 가 TS6133 으로 실패한다.
     //   이 sweep 이 그 미사용 const 를 자동 제거한다.
     try {
-      const pruneResult = await pruneUnusedAssetConsts(projectRoot);
-      if (pruneResult.totalRemoved > 0) {
-        console.log(
-          chalk.gray(
-            `   🧹 미사용 asset const ${pruneResult.totalRemoved}개 제거 (${pruneResult.changedFiles.length}개 파일)`,
-          ),
-        );
-      }
+      await pruneUnusedAssetConsts(projectRoot);
     } catch (pruneErr) {
       console.log(
         chalk.gray(`   ⚠️  미사용 asset const 정리(무시): ${pruneErr?.message || pruneErr}`),
       );
     }
 
-    // import 경로 확장자(.ts/.tsx 등) 결정론적 제거
-    // - Vite 코드가 './X.tsx' 같은 import 를 가졌을 때 Next.js 의 tsc 가
-    //   TS5097/TS2867 로 빌드를 거부하는 문제를 사전 차단한다.
-    try {
-      console.log('import 경로 확장자 정리 시작');
-      const stripResult = await stripImportExtensions(projectRoot);
-      if (stripResult.totalReplacements > 0) {
-        console.log(
-          chalk.gray(
-            `   🛠  import 경로 확장자 ${stripResult.totalReplacements}건 정리 (${stripResult.changedFiles.length}개 파일)`,
-          ),
-        );
-      } else {
-        console.log(chalk.gray('   ℹ️  import 경로 확장자 정리: 대상 없음'));
-      }
-      console.log('import 경로 확장자 정리 완료');
-    } catch (stripErr) {
-      console.log(chalk.gray(`   ⚠️  import 경로 정리(무시): ${stripErr?.message || stripErr}`));
-    }
-
-    // 타입 검사·자동 수정 구현체는 app/src/validation (여기서는 진입점만 호출)
-    if (options.skipValidation !== true) {
-      try {
-        console.log('TypeScript 검증 시작 (validation — tsc --noEmit)');
-        await runValidation(projectRoot, {
-          autofix: options.typecheckAutofix !== false,
-          aiFix: options.typecheckAiFix !== false,
-          aiFixBudget: options.typecheckAiFixBudget,
-        });
-        console.log('TypeScript 검증 완료');
-      } catch (typecheckErr) {
-        console.log(chalk.gray(`   ⚠️  타입 검증 단계 무시: ${typecheckErr?.message || typecheckErr}`));
-      }
-    }
-
-    if (options.report) {
-      const outputPath = options.outputPath || path.join(projectRoot, 'nextify-performance-report.md');
-      await generatePerformanceReport({
-        projectRoot,
-        baselineViteRoot: options.baselineViteRoot,
-        preStep7Root: options.preStep7Root,
-        outputMarkdownPath: outputPath,
-        lighthouseRuns: options.lighthouseRuns,
-        warmupRuns: options.warmupRuns,
-      });
-    }
-
-    console.log(chalk.green.bold('[7단계] 완료 — 성능 최적화가 끝났습니다.'));
+    console.log(chalk.green.bold('[6단계] 완료 — Next.js 심화 변환이 끝났습니다.'));
   } catch (error) {
-    console.error(chalk.red.bold('파트 7 오류 발생:'), error);
+    console.error(chalk.red.bold('Next.js 심화 변환 오류 발생:'), error);
     throw error;
   }
 }
 
-module.exports = { runStep7 };
+module.exports = {
+  runAdvancedMigration,
+  runStep7: runAdvancedMigration,
+};

--- a/app/src/step7/next-image-migrator.cjs
+++ b/app/src/step7/next-image-migrator.cjs
@@ -241,7 +241,7 @@ async function maybeMigrateInlineBackgroundImagesWithAi(projectRoot, srcDir, fin
 
   await stopAndOfferGeminiApply({
     projectRoot,
-    discoveryLine: `JSX style.backgroundImage( url / getImageUrl ) 패턴이 ${uniq.length}개 파일에서 감지되었습니다. next/image + fill + priority 로 바꾸면 LCP가 좋아집니다.`,
+    discoveryLine: `배경 이미지 최적화 후보 ${uniq.length}개가 발견되었습니다.`,
     discoverySources: uniq.slice(0, 15),
     instructionForAi: `Next.js App Router step7 LCP 작업입니다.
 

--- a/app/src/step7/performance-report.cjs
+++ b/app/src/step7/performance-report.cjs
@@ -441,9 +441,15 @@ async function ensureDependenciesInstalled(projectRoot) {
   const nodeModulesPath = path.join(projectRoot, 'node_modules');
   if (await fs.pathExists(nodeModulesPath)) return;
 
-  console.log(chalk.gray(`    → 의존성을 설치하는 중…`));
   const runtime = resolvePackageManagerCommand(projectRoot);
-  await runCommand(runtime.cmd, [...runtime.argsPrefix, 'install'], { cwd: projectRoot });
+  throw new Error(
+    `의존성이 설치되어 있지 않아 성능 레포트를 생성할 수 없습니다.\n` +
+      `아래 명령어로 패키지를 설치한 뒤 다시 실행하세요:\n` +
+      `  cd "${projectRoot}"\n` +
+      `  ${runtime.displayInstall}\n` +
+      `다시 실행:\n` +
+      `  migrate-next report`,
+  );
 }
 
 async function runBuild(projectRoot, kind) {
@@ -712,7 +718,7 @@ async function runLighthouseSeries(url, { runs = DEFAULT_LIGHTHOUSE_RUNS, warmup
     const runIndex = i + 1;
     console.log(
       chalk.gray(
-        `    ${isWarmup ? '준비 중' : `측정 중 (${runIndex - warmups}/${measuredRuns})`}…`
+        `    ${isWarmup ? '준비 중' : `측정 중 (${runIndex - warmups}/${measuredRuns})`}.`
       )
     );
     // eslint-disable-next-line no-await-in-loop
@@ -780,7 +786,7 @@ async function stopServerProcess(server) {
 }
 
 async function measureTarget({ label, projectRoot, kind, lighthouseRuns, warmupRuns }) {
-  console.log(chalk.gray(`\n  → ${label} 성능 측정 중…`));
+  console.log(chalk.gray(`\n  → ${label} 성능 측정 중.`));
   await runBuild(projectRoot, kind);
 
   const port = await getFreePort(kind === 'vite' ? 4173 : 3000);
@@ -1020,8 +1026,7 @@ const STEP_DESCRIPTIONS = [
   { step: 3, title: '라우팅 페이지 변환 (page.tsx/layout.tsx 생성)' },
   { step: 4, title: '스타일/리소스/공개 자산 이전' },
   { step: 5, title: "'use client' 처리 · Zustand 등 전역 상태 마이그레이션" },
-  { step: 6, title: '환경 변수 / 의존성 검토 가이드' },
-  { step: 7, title: 'next/image · next/font · 동적 import · 타입 보정' },
+  { step: 6, title: 'Next.js 심화 변환 (next/image · next/font · 동적 import · 타입 보정)' },
 ];
 
 function renderStepsSummaryTable({ finalStepNumber }) {
@@ -1428,8 +1433,8 @@ ${header}
 ## 비교 대상
 
 - Vite + React (원본)
-- Next.js (1~6단계, 성능 최적화 미적용)
-- Next.js (7단계 적용, 성능 최적화 적용)
+- Next.js (1~5단계, 기본 마이그레이션)
+- Next.js (1~6단계, Next.js 심화 변환 적용 시)
 
 ## 측정 지표
 
@@ -1439,7 +1444,7 @@ ${header}
 - FCP/LCP/SEO 표준편차(작을수록 안정적)
 - Total JS payload size (폴더 용량)
 
-## 변환 요약 (Step 1 ~ Step 7)
+## 변환 요약
 
 ${stepsTable}
 
@@ -1494,13 +1499,13 @@ async function readNextifyMeta(projectRoot) {
 }
 
 /**
- * pre-step7 스냅샷의 next.config.mjs 에 "측정 전용 빌드 완화" 옵션을 주입합니다.
+ * 기본 마이그레이션 스냅샷의 next.config.mjs 에 "측정 전용 빌드 완화" 옵션을 주입합니다.
  *
  * 이유:
- * - step7 의 마지막 단계는 "TypeScript 타입 검사 + AI 자동 수정" 입니다.
- *   이 보정은 메인 폴더(step1~7)에만 적용되고, pre-step7 스냅샷에는 잔존 타입
+ * - 심화 변환의 마지막 단계는 "TypeScript 타입 검사 + AI 자동 수정" 입니다.
+ *   이 보정은 메인 폴더(step1~6)에만 적용되고, 기본 마이그레이션 스냅샷에는 잔존 타입
  *   에러가 남습니다 (예: 사용 안 되는 React Router 코드의 children prop 누락).
- * - 그 결과 step1~6 baseline 측정 시 `next build` 가 type check 단계에서 실패하여
+ * - 그 결과 step1~5 baseline 측정 시 `next build` 가 type check 단계에서 실패하여
  *   Lighthouse 측정 자체가 불가능해집니다.
  * - 측정 목적상 type/eslint 정합성은 무관하므로 (런타임 perf 만 보면 됨) 빌드
  *   시점의 type/eslint 검사만 우회합니다. 멱등 — 이미 적용돼 있으면 skip.
@@ -1508,7 +1513,7 @@ async function readNextifyMeta(projectRoot) {
 async function injectMeasurementBuildOverrides(snapshotRoot) {
   const configPath = path.join(snapshotRoot, 'next.config.mjs');
   if (!(await fs.pathExists(configPath))) {
-    const fresh = `// [Nextify] pre-step7 측정 전용 빌드 완화 옵션\n` +
+    const fresh = `// [Nextify] 기본 마이그레이션 측정 전용 빌드 완화 옵션\n` +
       `/* __nextifyMeasurementOverridesApplied */\n` +
       `const nextConfig = {\n` +
       `  typescript: { ignoreBuildErrors: true },\n` +
@@ -1556,36 +1561,46 @@ async function injectMeasurementBuildOverrides(snapshotRoot) {
 
   console.warn(
     chalk.yellow(
-      `   ⚠️  pre-step7 스냅샷의 next.config.mjs 에 측정 완화 옵션을 자동 주입하지 못했습니다. ` +
-        `step1~6 baseline 빌드가 type 에러로 실패할 수 있습니다.`,
+      `   ⚠️  기본 마이그레이션 스냅샷의 next.config.mjs 에 측정 완화 옵션을 자동 주입하지 못했습니다. ` +
+        `step1~5 baseline 빌드가 type 에러로 실패할 수 있습니다.`,
     ),
   );
 }
 
-async function createPreStep7Snapshot(projectRoot) {
+async function createBaseMigrationSnapshot(projectRoot) {
   // IMPORTANT: 스냅샷을 프로젝트 "밖"에 둬야 fs-extra가 "자기 하위로 복사"를 막지 않습니다.
   const resolvedProjectRoot = path.resolve(projectRoot);
   const parentDir = path.dirname(resolvedProjectRoot);
   const projectName = path.basename(resolvedProjectRoot);
 
-  const snapshotRoot = path.join(parentDir, `${projectName}__nextify_snapshots`, 'pre-step7');
+  const snapshotRoot = path.join(parentDir, `${projectName}__nextify_snapshots`, 'post-step5');
   if (await fs.pathExists(snapshotRoot)) {
     await injectMeasurementBuildOverrides(snapshotRoot);
+    await ensureNextifyMeta(projectRoot, {
+      baseMigrationSnapshotRoot: snapshotRoot,
+    });
     return snapshotRoot;
   }
   await fs.ensureDir(path.dirname(snapshotRoot));
-  await cloneProject(projectRoot, snapshotRoot);
+  await cloneProject(projectRoot, snapshotRoot, {
+    silent: true,
+  });
   await injectMeasurementBuildOverrides(snapshotRoot);
   await ensureNextifyMeta(projectRoot, {
-    preStep7SnapshotRoot: snapshotRoot,
+    baseMigrationSnapshotRoot: snapshotRoot,
   });
   return snapshotRoot;
+}
+
+async function createPreStep7Snapshot(projectRoot) {
+  return createBaseMigrationSnapshot(projectRoot);
 }
 
 async function generatePerformanceReport({
   projectRoot,
   baselineViteRoot,
   preStep7Root,
+  baseMigrationRoot,
   outputMarkdownPath,
   lighthouseRuns,
   warmupRuns,
@@ -1598,19 +1613,27 @@ async function generatePerformanceReport({
   const viteRootResolved = baselineViteRoot || baselineFromMeta;
   if (!viteRootResolved) {
     throw new Error(
-      'Vite 원본 경로를 찾지 못했습니다. step1을 copy 모드로 실행했는지 확인하거나, step7 실행 시 --baseline <viteRoot> 옵션을 주세요.'
+      'Vite 원본 경로를 찾지 못했습니다. step1을 copy 모드로 실행했는지 확인하거나, report 실행 시 --baseline <viteRoot> 옵션을 주세요.'
     );
   }
 
-  const preRootResolved = preStep7Root || (await createPreStep7Snapshot(projectRoot));
+  const baseRootResolved =
+    baseMigrationRoot ||
+    preStep7Root ||
+    meta?.baseMigrationSnapshotRoot ||
+    meta?.preStep7SnapshotRoot ||
+    (await createBaseMigrationSnapshot(projectRoot));
+  const hasAdvancedMigration = Boolean(meta?.advancedCompleted || meta?.advanced?.completedAt);
 
   const targets = [];
   const failures = [];
   const measurePlans = [
     { label: 'Vite+React (baseline)', projectRoot: viteRootResolved, kind: 'vite' },
-    { label: 'Next.js (step1~6)', projectRoot: preRootResolved, kind: 'next' },
-    { label: 'Next.js (step1~7)', projectRoot, kind: 'next' },
+    { label: 'Next.js (step1~5)', projectRoot: baseRootResolved, kind: 'next' },
   ];
+  if (hasAdvancedMigration) {
+    measurePlans.push({ label: 'Next.js (step1~6 심화 변환)', projectRoot, kind: 'next' });
+  }
 
   for (const plan of measurePlans) {
     try {
@@ -1672,7 +1695,9 @@ async function generatePerformanceReport({
       outputMarkdownPath,
       generatedAt: new Date().toISOString(),
       baselineViteRoot: viteRootResolved,
-      preStep7Root: preRootResolved,
+      baseMigrationRoot: baseRootResolved,
+      preStep7Root: baseRootResolved,
+      advancedIncluded: hasAdvancedMigration,
       successfulTargets: targets.length,
       failedTargets: failures.length,
     },
@@ -1683,11 +1708,12 @@ async function generatePerformanceReport({
     return;
   }
 
-  console.log(chalk.green(`\n✅ 성능 레포트 생성 완료: ${outputMarkdownPath}\n`));
+  console.log(chalk.green(`\n✔ 성능 레포트 생성 완료: ${outputMarkdownPath}\n`));
 }
 
 module.exports = {
   generatePerformanceReport,
+  createBaseMigrationSnapshot,
   createPreStep7Snapshot,
   ensureNextifyMeta,
 };

--- a/app/src/utils/ai-file-apply.cjs
+++ b/app/src/utils/ai-file-apply.cjs
@@ -522,10 +522,6 @@ async function applyWithAutoBatching({
         const { written: w, rejected } = await applyAiFilesToDisk(projectRoot, patches, allowedRelPaths);
         written.push(...w);
         if (rejected.length > 0) {
-          // eslint-disable-next-line no-console
-          console.log(
-            `   🛡️  AI 패치 ${rejected.length}건을 syntax 회귀로 거부 (디스크는 원본 유지):`,
-          );
           for (const r of rejected) {
             // eslint-disable-next-line no-console
             console.log(`      - ${r.path} (syntax diag ${r.before} → ${r.after})`);
@@ -579,13 +575,7 @@ async function runAskApply(opts) {
   // 안전망 자체의 실패는 마이그레이션을 막지 않습니다.
   // ──────────────────────────────────────────────────────────────────
   try {
-    const { removedTargets } = await sweepAfterAiApply(projectRoot, written);
-    if (removedTargets.length > 0) {
-      // eslint-disable-next-line no-console
-      console.log(
-        `   🧹 사용처 없는 dead-guard ${removedTargets.length}개를 자동 정리했습니다.`
-      );
-    }
+    await sweepAfterAiApply(projectRoot, written);
   } catch (sweepErr) {
     // eslint-disable-next-line no-console
     console.log(

--- a/app/src/utils/copy.cjs
+++ b/app/src/utils/copy.cjs
@@ -3,8 +3,14 @@ const fs = require('fs-extra');
 const path = require('path');
 const ora = require('ora');
 
-async function cloneProject(source, destination) {
-  const spinner = ora('프로젝트를 복제하는 중...').start();
+async function cloneProject(source, destination, options = {}) {
+  const {
+    startMessage = '프로젝트를 복제하는 중...',
+    successMessage = `프로젝트 복제 완료: ${destination}`,
+    failMessage = '프로젝트 복제 실패',
+    silent = false,
+  } = options;
+  const spinner = silent ? null : ora(startMessage).start();
 
   try {
     await fs.copy(source, destination, {
@@ -32,9 +38,9 @@ async function cloneProject(source, destination) {
       await fs.copy(sourceGitignore, destGitignore, { overwrite: true });
     }
     
-    spinner.succeed(`프로젝트 복제 완료: ${destination}`);
+    if (spinner) spinner.succeed(successMessage);
   } catch (e) {
-    spinner.fail('프로젝트 복제 실패');
+    if (spinner) spinner.fail(failMessage);
     throw e;
   }
 }

--- a/app/src/utils/manual-flow.cjs
+++ b/app/src/utils/manual-flow.cjs
@@ -68,7 +68,7 @@ async function stopAndOfferGeminiApply(opts) {
     }
   }
 
-  console.log(chalk.yellow(`    🔍 ${discoveryLine}`));
+  console.log(chalk.white(`    🔍 ${discoveryLine}`));
   if (Array.isArray(discoverySources) && discoverySources.length > 0) {
     const uniq = [...new Set(discoverySources.map((s) => String(s).trim()).filter(Boolean))];
     if (uniq.length > 0) {
@@ -102,7 +102,7 @@ async function stopAndOfferGeminiApply(opts) {
     });
     spinner.stop();
     if (written.length > 0) {
-      printRelPathsBlock(chalk.green, '✅ Gemini 적용 완료', written, '    ');
+      printRelPathsBlock(chalk.green, '✔ Gemini 적용 완료', written, '    ');
     } else {
       console.log(chalk.gray('    Gemini가 수정할 내용을 찾지 못했습니다 — 이미 올바른 형태일 수 있습니다.'));
     }

--- a/app/src/utils/path-list-print.cjs
+++ b/app/src/utils/path-list-print.cjs
@@ -23,7 +23,7 @@ function normalizeRelPathsForDisplay(paths) {
 /**
  * 경로를 한 줄에 하나씩 출력. 개수가 많으면 상한까지만 보여 주고 나머지는 요약.
  * @param {(s: string) => string} style chalk.gray / chalk.green 등
- * @param {string} leadLine 제목(개수는 함수가 붙임). 예: "  발견 위치", "\n✅ Gemini 적용 완료"
+ * @param {string} leadLine 제목(개수는 함수가 붙임). 예: "  발견 위치", "\n✔ Gemini 적용 완료"
  * @param {string[]} paths
  */
 function printRelPathsBlock(style, leadLine, paths, indent = '') {

--- a/app/src/utils/project-info.cjs
+++ b/app/src/utils/project-info.cjs
@@ -97,8 +97,22 @@ function detectLanguage(cwd) {
 
 /**
  * 3. 빌드 도구 감지 (Vite vs CRA vs Other)
- * package.json의 의존성을 확인
+ * package.json 의존성, Vite 설정 파일, scripts를 함께 확인
  */
+function hasViteConfig(cwd) {
+  return ['vite.config.ts', 'vite.config.js', 'vite.config.mjs', 'vite.config.mts'].some((file) =>
+    fs.existsSync(path.join(cwd, file)),
+  );
+}
+
+function hasViteScript(pkg) {
+  const scripts = pkg?.scripts || {};
+  return Object.values(scripts).some((script) => {
+    if (typeof script !== 'string') return false;
+    return /(^|\s|&&|\|\||;)(cross-env\s+[^&;|]*\s+)?vite(\s|$)/.test(script);
+  });
+}
+
 function detectBuildTool(cwd) {
   const pkgPath = path.join(cwd, 'package.json');
 
@@ -111,6 +125,8 @@ function detectBuildTool(cwd) {
     const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
 
     if (allDeps['vite']) return 'vite';
+    if (hasViteConfig(cwd)) return 'vite';
+    if (hasViteScript(pkg)) return 'vite';
     if (allDeps['react-scripts']) return 'cra'; // Create React App
     return 'other';
   } catch (e) {

--- a/app/src/utils/review-session.cjs
+++ b/app/src/utils/review-session.cjs
@@ -75,7 +75,9 @@ async function createStepReviewSession(projectRoot, stepName, executeStep) {
   await fs.ensureDir(filesRoot);
   await fs.ensureDir(placeholdersRoot);
   await fs.remove(previewRoot);
-  await cloneProject(projectRoot, previewRoot);
+  await cloneProject(projectRoot, previewRoot, {
+    silent: true,
+  });
 
   const previousAssumeYes = process.env.NEXTIFY_ASSUME_YES;
   process.env.NEXTIFY_ASSUME_YES = '1';
@@ -527,7 +529,9 @@ async function createSnapshotReviewSession(projectRoot, stepName, executeStep) {
   // "Cannot copy ... to a subdirectory of itself" 에러가 발생할 수 있으므로
   // 먼저 OS temp에 복제한 뒤 sessionRoot로 이동합니다.
   await fs.remove(beforeTempRoot);
-  await cloneProject(projectRoot, beforeTempRoot);
+  await cloneProject(projectRoot, beforeTempRoot, {
+    silent: true,
+  });
   await fs.remove(beforeRoot);
   await fs.move(beforeTempRoot, beforeRoot, { overwrite: true });
 

--- a/app/src/validation/typecheck-report.cjs
+++ b/app/src/validation/typecheck-report.cjs
@@ -30,6 +30,7 @@ const {
   writeStaticImportReport,
 } = require('./static-import-scan.cjs');
 const { sweepAfterAiApply } = require('../utils/post-ai-sweep.cjs');
+const { stripImportExtensions } = require('../utils/strip-import-extensions.cjs');
 
 const REPORT_FILE_NAME = 'nextify-typecheck-report.txt';
 const TSCONFIG_FILE_NAME = 'tsconfig.json';
@@ -175,6 +176,13 @@ function buildPackageManagerTscCommand(projectRoot) {
   }
   // npm 또는 lockfile 없음
   return { cmd: ext('npx'), prefix: ['-y', 'tsc'] };
+}
+
+function getBuildCommand(projectRoot) {
+  if (fs.existsSync(path.join(projectRoot, 'yarn.lock'))) return 'yarn build';
+  if (fs.existsSync(path.join(projectRoot, 'pnpm-lock.yaml'))) return 'pnpm build';
+  if (fs.existsSync(path.join(projectRoot, 'bun.lockb'))) return 'bun run build';
+  return 'npm run build';
 }
 
 /**
@@ -397,6 +405,23 @@ async function runFinalTypecheckReport(projectRoot, options = {}) {
     return { ran: false, reason: 'no_tsconfig' };
   }
 
+  // ── 0) TypeScript 검증 전 import 경로 보정 ───────────────────────────
+  // Vite 코드에 남은 './File.tsx' 형태는 Next.js/tsc에서 TS5097/TS2867을 만들 수 있습니다.
+  try {
+    const stripResult = await stripImportExtensions(projectRoot);
+    if (stripResult.totalReplacements > 0) {
+      console.log(
+        chalk.gray(
+          `   TypeScript 검증 전 import 경로를 정리했습니다. (${stripResult.totalReplacements}건, ${stripResult.changedFiles.length}개 파일)`,
+        ),
+      );
+    }
+  } catch (e) {
+    console.log(
+      chalk.gray(`   ⚠️  TypeScript 검증 전 import 경로 정리 중 오류가 발생했습니다. 마이그레이션은 계속 진행합니다: ${e?.message || e}`),
+    );
+  }
+
   // ── 0) 결정론적 src/ 전체 sweep (typecheck 직전 안전망) ─────────────
   // step5/7 의 여러 Gemini 호출에서 sweep 가 누락된 파일이 있을 수 있고,
   // 호출 순서로 인해 dead 가 된 후 sweep 가 한 번도 안 도는 경우(예: layout.tsx
@@ -422,43 +447,31 @@ async function runFinalTypecheckReport(projectRoot, options = {}) {
       const r = await sweepAfterAiApply(projectRoot, allRel);
       if (r.removedTargets.length > 0) {
         console.log(
-          chalk.cyan(
-            `   typecheck 직전 src/ 결정론 sweep: ${r.removedTargets.length}건 정리 (${r.changedFiles.length}개 파일)`,
+          chalk.gray(
+            `   타입 검사 전, 마이그레이션 과정에서 남은 불필요한 임시 코드를 정리했습니다. (${r.removedTargets.length}건, ${r.changedFiles.length}개 파일)`,
           ),
         );
       }
     }
   } catch (e) {
     console.log(
-      chalk.gray(`   ⚠️  typecheck 직전 sweep 중 오류(무시): ${e?.message || e}`),
+      chalk.gray(`   ⚠️  타입 검사 전 임시 코드 정리 중 오류가 발생했습니다. 마이그레이션은 계속 진행합니다: ${e?.message || e}`),
     );
   }
 
   // ── 1차 tsc ──────────────────────────────────────────────────────────
-  console.log(chalk.gray('   ⏳ TypeScript 타입 검사 중 (tsc --noEmit) ...'));
+  console.log(chalk.gray('   TypeScript 타입 검사 중...'));
   const t0 = Date.now();
   const first = runTscAndParse(projectRoot);
   if (!first.ok) {
-    console.log(
-      chalk.gray(`   ⚠️  타입 검사를 건너뜁니다: ${first.message || first.reason}`),
-    );
-    // 진단: 어떤 명령으로 시도했는지·이유 요약을 노출해 사용자가
-    // 환경(yarn berry/PnP 등) 문제를 바로 파악할 수 있게 한다.
-    const hint = describeTscInvocation(projectRoot);
-    if (hint) {
-      console.log(chalk.gray(`      ↳ 실행 방식: ${hint}`));
-    }
-    if (first.stderr) {
-      const head = String(first.stderr).split(/\r?\n/).filter(Boolean).slice(0, 3);
-      for (const line of head) {
-        console.log(chalk.gray(`      ↳ stderr: ${line}`));
-      }
-    }
+    console.log(chalk.yellow('   TypeScript 검증을 실행하지 못했습니다.'));
+    console.log(chalk.gray('   마이그레이션 결과는 유지됩니다.'));
+    console.log(chalk.gray(`   의존성 설치 후 \`${getBuildCommand(projectRoot)}\`로 직접 확인하세요.`));
     return { ran: false, reason: first.reason };
   }
 
   if (first.exitCode === 0 && first.errors.length === 0) {
-    console.log(chalk.green('   ✅ 타입 검사 통과: 별다른 unused/type 에러가 없습니다.'));
+    console.log(chalk.green('   TypeScript 검증 완료: 문제 없음'));
     try {
       staticImportScan = await runStaticImportScan(projectRoot);
       if (staticImportScan.ran && staticImportScan.missing.length > 0) {
@@ -525,7 +538,7 @@ async function runFinalTypecheckReport(projectRoot, options = {}) {
       autofixSummary = await autofixErrors(projectRoot, firstSplit.project);
       if (autofixSummary.totalFixed > 0) {
         console.log(
-          chalk.cyan(
+          chalk.white(
             `   패턴 기반 자동 수정: ${autofixSummary.totalFixed}건 (${autofixSummary.fixedFiles.length}개 파일)`,
           ),
         );
@@ -605,7 +618,7 @@ async function runFinalTypecheckReport(projectRoot, options = {}) {
       );
     } else {
       console.log(
-        chalk.cyan(
+        chalk.white(
           `   🤖 AI 보정 시도: 프로젝트 잔여 ${secondSplit.project.length}건을 파일당 1회씩, 최대 ${aiFixBudget}개 파일 의뢰`,
         ),
       );
@@ -669,7 +682,7 @@ async function runFinalTypecheckReport(projectRoot, options = {}) {
           const aiDelta = beforeAi.length - finalErrors.length;
           if (aiSummary.filesChanged.length > 0) {
             console.log(
-              chalk.cyan(
+              chalk.white(
                 `   Gemini 수정 결과: ${aiSummary.filesChanged.length}개 파일 변경, ${aiDelta >= 0 ? aiDelta : 0}건 해소`,
               ),
             );
@@ -684,10 +697,10 @@ async function runFinalTypecheckReport(projectRoot, options = {}) {
   // ── 5) 최종 리포트 ──────────────────────────────────────────────────
   if (finalErrors.length === 0 && finalExit === 0) {
     const summary = [
-      `   ✅ 타입 검사 통과 (총 ${(elapsedMs / 1000).toFixed(1)}s)`,
+      `   TypeScript 검증 완료: 문제 없음 (총 ${(elapsedMs / 1000).toFixed(1)}s)`,
     ];
     if (autofixSummary.totalFixed > 0) {
-      summary.push(`      • 패턴 기반 자동 수정: ${autofixSummary.totalFixed}건`);
+      summary.push(`      • 자동 수정으로 일부 타입 오류를 정리했습니다. (${autofixSummary.totalFixed}건)`);
     }
     if (aiSummary.filesChanged.length > 0) {
       summary.push(`      • Gemini 수정: ${aiSummary.filesChanged.length}개 파일`);
@@ -757,9 +770,10 @@ async function runFinalTypecheckReport(projectRoot, options = {}) {
   console.log('');
   console.log(
     chalk.yellow.bold(
-      `   ⚠️  타입 검사 경고: ${total}개의 잠재적 빌드 에러가 남아있습니다.`,
+      '   TypeScript 검증 완료: 추가 확인 필요',
     ),
   );
+  console.log(chalk.gray(`      남은 항목: ${total}건`));
   if (labelSummary.length > 0) {
     console.log(chalk.gray('      [라벨/레버 매칭 상위]'));
     for (const x of labelSummary.slice(0, 5)) {
@@ -803,9 +817,9 @@ async function runFinalTypecheckReport(projectRoot, options = {}) {
   }
 
   console.log('');
-  console.log(chalk.cyan(`      📄 자세한 내용: ${reportPath}`));
+  console.log(chalk.white(`      자세한 내용은 ${REPORT_FILE_NAME}에서 확인하세요.`));
   console.log(
-    chalk.cyan(
+    chalk.gray(
       `      🛠  수동 점검: 프로젝트 루트에서 \`npx tsc --noEmit\` 을 다시 실행해 위치를 확인하세요.`,
     ),
   );


### PR DESCRIPTION
## 작업 내용

- 기본 `migrate-next` 플로우를 step1~step5 기본 마이그레이션 중심으로 정리
- 기존 step7 기능을 step6 `Next.js 심화 변환`으로 재정의하고 `migrate-next advanced` 명령 추가
- 성능 레포트와 AI 코드 리뷰를 자동 실행 대신 `migrate-next report`, `migrate-next review` 명령으로 분리
- 기본/심화 변환 후 최종 안내 문구를 통일하고, 의존성 재설치/빌드 확인/추가 명령어 안내 개선
- TypeScript 검증을 기본 마이그레이션과 심화 변환 이후 별도 단계로 자동 실행되도록 정리
- import 경로 확장자 보정을 TypeScript 검증 전 공통 보정 단계로 이동
- 성능 레포트 비교용 데이터 생성 시 내부 경로 대신 목적 중심 안내 출력
- 복사본/원본 직접 적용 모드에 따라 후속 명령어 실행 위치 안내 분기
- CLI 로그 색상 기준 정리: 섹션 파란색, 성공 초록색, 일반 안내 흰색, 보조 정보 회색, 경고 노란색
- 내부 보정/임시 복사 관련 불필요한 로그와 혼동되는 이모지 로그 제거
- Vite 프로젝트 감지 기준을 dependency뿐 아니라 `vite.config.*`와 scripts까지 포함하도록 개선